### PR TITLE
Raspi install additional steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Demonstrated in the video below:
    * Try::Tiny
    * Cache::FileCache
    * JSON
+ * Note on Raspberry Pi some CPAN Modules will time out if the command to install them is not run in verbose mode, for instance: "curl -L https://cpanmin.us | perl - -M https://cpan.metacpan.org/ -n IO::Termios --verbose"
+ * Note also, on Raspberry Pi, expat-devel must be installed before installing Wunderground for parsing, so you should do "apt-get install expat libexpat1-dev"
 
 ##### Hardware
  * Basic hardware capable of running Linux. This could be a desktop machine, a Raspberry Pi, or an embedded device. The author runs Infinitude on ArchLinux using a [Pogoplug v4](http://www.amazon.com/Pogoplug-Series-4-Backup-Device/dp/B006I5MKZY/ref=sr_1_1?ie=UTF8&tag=sbhq-20&qid=1415825203&sr=8-1&keywords=pogoplug) which can be obtained for less than $20 USD and sits on top of the air handler like so:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Demonstrated in the video below:
    * [WWW::Wunderground::API](https://metacpan.org/module/WWW::Wunderground::API)
    * [IO::Termios](https://metacpan.org/module/IO::Termios) optional for RS485 serial monitoring
    * Try::Tiny
+   * Cache::FileCache
+   * JSON
 
 ##### Hardware
  * Basic hardware capable of running Linux. This could be a desktop machine, a Raspberry Pi, or an embedded device. The author runs Infinitude on ArchLinux using a [Pogoplug v4](http://www.amazon.com/Pogoplug-Series-4-Backup-Device/dp/B006I5MKZY/ref=sr_1_1?ie=UTF8&tag=sbhq-20&qid=1415825203&sr=8-1&keywords=pogoplug) which can be obtained for less than $20 USD and sits on top of the air handler like so:


### PR DESCRIPTION
I just got it working on a Raspberry Pi running Rasbian today.  Needed two more CPAN modules and also had some errors when doing the CPAN installs.  

After that it starts as ./infinitude daemon just fine.  

I have a Bryant Evolution V with a wifi thermostat and communicating fan coil (the 005 one) and will likely do some more pull requests with the Bryant stuff since the api server names are different for the proxy part.  Maybe a command line flag to say if it's Bryant or Carrier.