### PR TITLE
Add 5-stage compressor so it parses nicely

### DIFF
--- a/lib/CarBus/Frame.pm
+++ b/lib/CarBus/Frame.pm
@@ -11,6 +11,7 @@ my %device_classes = (
 	FanCoil => 0x42,
 	HeatPump0 => 0x50,
 	HeatPump1 => 0x51,
+	HeatPump2 => 0x52,
 	SAM => 0x92,
 	Broadcast => 0xF1,
 	_default_ => $DefaultPass


### PR DESCRIPTION
Added address 0x52 from my system - a 5-stage outside unit (compressor)

Added as HeatPump2 (even though it's not) as trying a new name (like 5StgComp) broke something.  Haven't tracked that down.