### PR TITLE
Add missing Hash::AsObject dependency

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -4,6 +4,7 @@ requires 'DateTime';
 requires 'Try::Tiny';
 requires 'Path::Tiny';
 requires 'JSON';
+requires 'Hash::AsObject';
 
 suggests 'WWW::Wunderground::API';
 suggests 'IO::Termios';


### PR DESCRIPTION
This commit adds a missing dependency to the cpanfile for the project.
Hash::AsObject is used in lib/XML/Simple/Minded.pm, but it was not in
the cpanfile indicating it's a requirement. This corrects the oversight.