### PR TITLE
Fix failure to return correct response payload to t-stat

### DIFF
--- a/infinitude
+++ b/infinitude
@@ -106,7 +106,6 @@ hook before_dispatch => sub {
 				$store->set("$store_key.raw", $data);
 				$store->set("$store_key.xml" , $xml.'');
 				$store->set("$store_key.json", $xml->_as_json);
-				$c->stash->{data} = $xml;
 				$c->stash(store_key=>$store_key);
 			} catch {
 				$c->stash('error','true');


### PR DESCRIPTION
Many of the stash values are reserved. These include:
action, app, cb, controller, data, extends, format, handler, inline,
json, layout, namespace, path, status, template, text and variant

Setting stash(data) interferes with the processing of render() and
causes the payload in the response to be copied from the request.
Consequently, POST status from the t-stat never sees a change flag and
doesn't request an updated config.

The stash(data) line isn't ever referenced, so just drop it.

This seems to address issue 38.