### PR TITLE
Set pingRate to 20 seconds

### DIFF
--- a/infinitude
+++ b/infinitude
@@ -330,6 +330,7 @@ post '/systems/:system_id/status' => sub {
 	if (!$changes and $c->stash->{pass_res}) {
 	  $c->app->log->debug("********** Check Carrier/Bryant change flags ****************");
 	  $xml = XML::Simple::Minded->new($c->stash->{pass_res});
+	  $xml->status->pingRate([12]);
 	  $changes = $xml->status->serverHasChanges eq 'true' ? 1 : 0;
 	  $store->set(carrier_changes => time, 120) if $changes; # open a window to Carrier passthru, max of 2 minutes
 	}


### PR DESCRIPTION
In the case where the status response is returned from the
Bryant/Carrier web site, the pingRate is returned to 3 minutes.
This stops the t-stat from updating infinitude for that period.