### PR TITLE
Support for Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,36 @@ Many users opt to run Infinitude on a Raspberry Pi.
 
 See <a target="_blank" href="http://www.amazon.com/Infinitude-hardware/lm/R2G4T8HWC1AQDK/?_encoding=UTF8&camp=1789&creative=390957&linkCode=ur2&tag=sbec-20&linkId=THB3EP6RU76EIXOA">Infinitude Hardware</a><img src="https://ir-na.amazon-adsystem.com/e/ir?t=sbec-20&l=ur2&o=1" width="1" height="1" border="0" alt="" style="border:none !important; margin:0px !important;" /> for recommended devices.
 
+#### Docker
+Docker support is provided in the `docker` directory.
+
+Infinitude configuration parameters can be passed through environment variables into the container.  Support is included for:
+
+| Variable | 
+| --- | 
+| APP_SECRET | 
+| PASS_REQS | 
+| WUNDERGROUND_KEY | 
+| MODE | 
+
+The latest docker image can be built directly from this repository
+
+```docker build -t infinitude https://raw.githubusercontent.com/nebulous/infinitude/master/docker/Dockerfile```
+
+and the corresponding container can be run as
+```
+docker run \
+-e APP_SECRET='YOUR_SECRET_HERE' \
+-e PASS_REQS='1020' \
+-e WUNDERGROUND_KEY='YOUR_KEY_HERE' \
+-e MODE='Production' \
+-p 3000:3000 \
+--name infinitude docker_infinitude
+```
+
+An [example docker-compose file](https://github.com/nebulous/infinitude/blob/master/docker/docker-compose.yaml) is also included.
+
+
 #### Usage
  * Set your proxy server/port in the advanced wireless settings on the thermostat to point to your infinitude host/port. 
  * Edit the $conf section of the infinitude file to set your optional Wunderground API key or RS485 serial tty device.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,8 @@ RUN apt-get update && apt-get -y upgrade \
 	&& git clone https://github.com/nebulous/infinitude.git /infinitude \ 
     && chmod +x /infinitude/infinitude \
     && cd /infinitude \
-    && cpanm Mojolicious::Lite CHI DateTime Try::Tiny Path::Tiny JSON WWW::Wunderground::API IO::Termios
+    && cpanm Mojolicious::Lite CHI DateTime Try::Tiny Path::Tiny JSON IO::Termios \
+    && cpanm --force  WWW::Wunderground::API
 COPY ./entrypoint.sh /
 EXPOSE 3000
 ENTRYPOINT /entrypoint.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:latest
+
+RUN apt-get update && apt-get -y upgrade \
+	&& apt-get install -y git build-essential cpanminus libchi-perl libmojolicious-perl libdatetime-perl libxml-simple-perl libmoo-perl libjson-maybexs-perl libhash-asobject-perl libdata-parsebinary-perl libdigest-crc-perl libcache-perl libtest-longstring-perl libio-pty-perl \
+	&& git clone https://github.com/nebulous/infinitude.git /infinitude \ 
+    && chmod +x /infinitude/infinitude \
+    && cd /infinitude \
+    && cpanm Mojolicious::Lite CHI DateTime Try::Tiny Path::Tiny JSON WWW::Wunderground::API IO::Termios
+COPY ./entrypoint.sh /
+EXPOSE 3000
+ENTRYPOINT /entrypoint.sh

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,18 @@
+version: "2.1"
+
+services:
+  infinitude:
+    container_name: infinitude
+    hostname: infinitude
+    build:
+      context: .
+      dockerfile: Dockerfile
+    network_mode: host
+    environment:
+      - APP_SECRET=Pogotudinal
+      - PASS_REQS=1020
+      - WUNDERGROUND_KEY=<INSERT_YOUR_KEY>
+      - MODE=Production
+#    devices:
+#      - /dev/ttyUSB0:/dev/ttyUSB0
+    restart: always

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -8,10 +8,12 @@ services:
       context: .
       dockerfile: Dockerfile
     network_mode: host
+    ports:
+      - "3000:3000"
     environment:
       - APP_SECRET=Pogotudinal
       - PASS_REQS=1020
-      - WUNDERGROUND_KEY=<INSERT_YOUR_KEY>
+      - WUNDERGROUND_KEY=YOUR_KEY_KERE
       - MODE=Production
 #    devices:
 #      - /dev/ttyUSB0:/dev/ttyUSB0

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Generate the config file from environment variables
+echo "{\"app_secret\":\"$APP_SECRET\",\"pass_reqs\":$PASS_REQS,\"serial_tty\":\"/dev/ttyUSB0\",\"wunderground_key\":\"$WUNDERGROUND_KEY\"}" > /infinitude/infinitude.json
+
+if [ -z ${MODE+x} ]; then 
+	echo "MODE is not set.  Defaulting to Production";
+	MODE=Production
+else 
+	echo "MODE is set to $MODE"; 
+fi
+
+cd /infinitude && ./infinitude daemon -m $MODE


### PR DESCRIPTION
This PR provides a Dockerfile and example Docker Compose file that builds the latest Infinitude source on a Ubuntu base.  Configuration options are exposed via Docker environment variables.

This is a setup I initially had working about a year ago.  While assembling this PR I found that WWW::Wunderground::API is now throwing errors and causing the image build to fail.  This error is probably not unique to Docker - it probably impacts any new install of Infinitude.

Regardless, this image requires some further troubleshooting before being merged, but I wanted to at least create the PR to get it rolling.