### PR TITLE
Set entrypoint inside cloned repository.  Fixes #76

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,6 +6,5 @@ RUN apt-get update && apt-get -y upgrade \
     && chmod +x /infinitude/infinitude \
     && cd /infinitude \
     && cpanm Mojolicious::Lite CHI DateTime Try::Tiny Path::Tiny JSON IO::Termios
-COPY ./entrypoint.sh /
 EXPOSE 3000
-ENTRYPOINT /entrypoint.sh
+ENTRYPOINT /infinitude/docker/entrypoint.sh


### PR DESCRIPTION
Closes #76 

This resolves issues with relative paths during the Dockerfile build by referencing the entrypoint Infinitude repository that is cloned into the container, rather than copying the entrypoint script from an external location at build time.

It ensures that the Docker instructions in the README, which describe building directly from GitHub, will work correctly.