### PR TITLE
make docker-compose file work?

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,10 +5,7 @@ services:
     container_name: infinitude
     hostname: infinitude
     image: nebulous/infinitude:latest
-    build:
-      context: .
-      dockerfile: Dockerfile
-    network_mode: host
+    network_mode: bridge
     ports:
       - "3000:3000"
     volumes:


### PR DESCRIPTION
the build context breaks this file for those who just want to pull this yaml file and then do docker-compose up - suggesting we remove it unless there is some reason not to?
the network mode of host breaks on my latest docker hosts as ports definition is incompatible with host mode (apparently) - suggest we change to bridge unless there is some reason not to?

(aka i am pretty certain buildx is using the dockerfile directly and not this docker-compose)