### PR TITLE
Avoid reserved stash value in config variable endpoint

### DIFF
--- a/infinitude
+++ b/infinitude
@@ -218,11 +218,11 @@ any '/api/:zone_id/activity/:activity_id' => sub {
 };
 
 # access simple system config variables by path
-any '/api/*path' => sub {
+any '/api/*variable_path' => sub {
 	my $c = shift;
 	my $xml = XML::Simple::Minded->new($store->get('systems.xml'));
 	my $search = $xml->system();
-	foreach my $node (split('/',$c->stash('path'))) {
+	foreach my $node (split('/',$c->stash('variable_path'))) {
 		$search = ($node =~ /^\d+$/) ? $search->[$node]
 		                             : $search->$node;
 	}


### PR DESCRIPTION
This fixes the "Route pattern "/api/*path" contains a reserved
stash value at /usr/share/perl5/Mojolicious/Lite.pm line 33." error
on recent Mojolicious versions that was preventing Infinitude from
starting.