### PR TITLE
Allow specifying the loglevel with the LOGLEVEL envvar

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ Infinitude configuration parameters can be passed through environment variables 
 | PASS_REQS | Minimum amount of time to wait(in seconds) between requests to Carrier/Bryant servers. `0` means never. |
 | MODE | `production`(default) or `development`(more logging) |
 | SERIAL_TTY | optional rs485 device string eg `/dev/ttyUSB0` |
-| SERIAL_SOCKET | optional tcp/rs485 bridge string eg `192.168.1.42:23` | 
+| SERIAL_SOCKET | optional tcp/rs485 bridge string eg `192.168.1.42:23` |
+| LOGLEVEL | optional [minimum severity of log messages to print](https://docs.mojolicious.org/Mojo/Log#level) |
 
 
 the published container can be run as

--- a/infinitude
+++ b/infinitude
@@ -115,7 +115,7 @@ hook before_dispatch => sub {
 				$c->stash(store_key=>$store_key);
 			} catch {
 				$c->stash('error','true');
-				$c->app->log->info($url, shortmess(), "Caught error: $_".$@);
+				$c->app->log->error($url, shortmess(), "Caught error: $_".$@);
 				$store->set("error-".time() => 'url:'.$url."\nerror: $_\ndata:".$data);
 			};
 		}
@@ -408,7 +408,7 @@ websocket '/serial' => sub {
 		});
 		$stream->on(error=>sub {
 			my ($stream, $err) = @_;
-			$c->app->log->info("ERROR $err");
+			$c->app->log->error("ERROR $err");
 		});
 		$stream->on(close=>sub {
 			my ($stream) = @_;
@@ -455,4 +455,6 @@ any '/*catchall' => sub {
 	$c->render(text=>$text, format=>$format);
 };
 
+app->log->level($ENV{LOGLEVEL}//'trace');
 app->start;
+


### PR DESCRIPTION
Printing 3 lines every time the thermostat makes a request every 12
seconds in production seems a bit excessive, so allow for the
loglevel to be specified at runtime to reduce logging verbosity.
Also, increase the severity of a few serious-looking log statements
so they still get printed even when higher log levels are
specified.