### PR TITLE
Fix hold activity dropdown always resetting to "home" on load

### DIFF
--- a/public/app/views/profiles.html
+++ b/public/app/views/profiles.html
@@ -26,7 +26,7 @@
 		<div class="panel-heading"><strong>whole house</strong>
 			<br>Hold: <input type="checkbox" ng-model="systems.config[0].wholeHouse[0].hold[0]" ng-true-value="'on'" ng-false-value="'off'">
 			<span ng-if="systems.config[0].wholeHouse[0].hold[0] == 'on'">
-			<select name="holdact" ng-init="systems.config[0].wholeHouse[0].holdActivity[0] = 'home'" ng-model="systems.config[0].wholeHouse[0].holdActivity[0]">
+			<select name="holdact" ng-init="systems.config[0].wholeHouse[0].holdActivity[0] !== 'none' || (systems.config[0].wholeHouse[0].holdActivity[0] = 'home')" ng-model="systems.config[0].wholeHouse[0].holdActivity[0]">
 				<option>home</option>
 				<option>away</option>
 			</select>
@@ -142,7 +142,7 @@
 		<div class="panel-heading"><strong>{{zone.name[0]}}</strong>
 			<span ng-if="zone.enabled[0] == 'on'"><br>Hold: <input type="checkbox" ng-model="zone.hold[0]" ng-true-value="'on'" ng-false-value="'off'">
 			<span ng-if="zone.hold[0] == 'on'">
-			<select name="holdact" ng-init="zone.holdActivity[0] = 'home'" ng-model="zone.holdActivity[0]">
+			<select name="holdact" ng-init="angular.equals(zone.holdActivity[0], {}) || (zone.holdActivity[0] = 'home')" ng-model="zone.holdActivity[0]">
 				<option>home</option>
 				<option>away</option>
 				<option>sleep</option>


### PR DESCRIPTION
In https://github.com/nebulous/infinitude/commit/6dd47b6adca250c33606cc81d2d17b7a7d38f332
I added an ng-init on the hold activity dropdowns to make them
default to the first option instead of displaying an empty option,
which would yield unexpected results if saved.  However, this
introduced a bug whereby the dropdown would always be set to the
first option whenever it was displayed, even if another value was
already selected.  This fixes that bug by checking to see if the
hold activity has the default value ("none" for wholeHouse and {}
for zones) and only setting it in that case.