### PR TITLE
Fix uninitialized value error in logging

### DIFF
--- a/infinitude
+++ b/infinitude
@@ -455,6 +455,6 @@ any '/*catchall' => sub {
 	$c->render(text=>$text, format=>$format);
 };
 
-app->log->level($ENV{LOGLEVEL}//'trace');
+app->log->level($ENV{LOGLEVEL}//app->log->level);
 app->start;
 


### PR DESCRIPTION
https://github.com/nebulous/infinitude/commit/ffda1454c2d4e20cdb1b178be51a32b91a28d50a
added the ability for the user to specify the log level using the
LOGLEVEL envvar and it set the fallback to "trace" to match the
default in Mojo.  However, it turns out that the trace loglevel
was only recently added and specifying an unknown loglevel results
in an uninitialized value error.  Instead, set the fallback to
whatever the current log level is.  This fixes https://github.com/nebulous/infinitude/issues/139.