### PR TITLE
Pass arguments to infinitude in docker container

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,4 +10,4 @@ else
 	echo "MODE is set to $MODE";
 fi
 
-cd /infinitude && ./infinitude daemon -m $MODE
+cd /infinitude && ./infinitude daemon -m $MODE $@


### PR DESCRIPTION
Hi there! I was trying to set the port of an infinitude instance in a docker container using the `-l` flag, but realized that the argument wouldn't be passed to the infinitude binary because the entrypoint script doesn't handle arguments. So, I added support for that. Not sure if this is exactly what you want though, so feel free to close if it's undesirable.

```shell
# Before:
$ docker run nebulous/infinitude --help
MODE is set to Production
[2022-07-03 17:52:22.08031] [7] [info] Listening at "http://*:3000"
# After:
$ docker run revised_infinitude --help 
MODE is set to Production
Usage: APPLICATION daemon [OPTIONS]

  ./myapp.pl daemon
  ./myapp.pl daemon -m production -l http://*:8080
  ./myapp.pl daemon -l http://127.0.0.1:8080 -l https://[::]:8081
  ./myapp.pl daemon -l 'https://*:443?cert=./server.crt&key=./server.key'
  ./myapp.pl daemon -l http+unix://%2Ftmp%2Fmyapp.sock

Options:
  -b, --backlog <size>                 Listen backlog size, defaults to
                                       SOMAXCONN
  -c, --clients <number>               Maximum number of concurrent
                                       connections, defaults to 1000
  -h, --help                           Show this summary of available options
      --home <path>                    Path to home directory of your
                                       application, defaults to the value of
                                       MOJO_HOME or auto-detection
  -i, --inactivity-timeout <seconds>   Inactivity timeout, defaults to the
                                       value of MOJO_INACTIVITY_TIMEOUT or 15
  -l, --listen <location>              One or more locations you want to
                                       listen on, defaults to the value of
                                       MOJO_LISTEN or "http://*:3000"
  -m, --mode <name>                    Operating mode for your application,
                                       defaults to the value of
                                       MOJO_MODE/PLACK_ENV or "development"
  -p, --proxy                          Activate reverse proxy support,
                                       defaults to the value of
                                       MOJO_REVERSE_PROXY
  -r, --requests <number>              Maximum number of requests per
                                       keep-alive connection, defaults to 100
```