### PR TITLE
Update cpanfile to add three required dependencies

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -6,5 +6,8 @@ requires 'Path::Tiny';
 requires 'JSON';
 requires 'Hash::AsObject';
 requires 'XML::Simple';
+requires 'Moo';
+requires 'Data::ParseBinary';
+requires 'Digest::CRC';
 
 suggests 'IO::Termios';


### PR DESCRIPTION
I installed Infinitude manually on one of my systems today and found that it required three additional dependencies beyond what were listed in the cpanfile: 

Moo
Data::ParseBinary
Digest::CRC