### PR TITLE
Configure Dockerfile base-image with build arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM debian:latest
+ARG BASE_IMAGE=debian:latest
+FROM ${BASE_IMAGE}
 
 COPY . /infinitude
 WORKDIR /infinitude


### PR DESCRIPTION
This allows for confiugring the base image of the Dockerfile with custom input, while preserving previous behavior.