### PR TITLE
Payload parsing

### DIFF
--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -10,19 +10,17 @@ services:
       context: .
       dockerfile: Dockerfile
     network_mode: host
-    ports:
-      - "3000:3000"
     volumes:
       - ./:/infinitude/
     environment:
       - APP_SECRET=Pogotudinal
       - PASS_REQS=300
-      - SERIAL_TTY=/dev/ttyUSB0
-      #- SERIAL_SOCKET=192.168.1.47:23
+      #- SERIAL_TTY=/dev/ttyUSB0
+      - SERIAL_SOCKET=192.168.1.23:23
       - MOJO_MODE=development
       - MOJO_LOG_COLOR=1
       - MOJO_LOG_LEVEL=debug
       - SCAN_THERMOSTAT=1
-    devices:
-      - /dev/ttyUSB0:/dev/ttyUSB0
+#    devices:
+#      - /dev/ttyUSB0:/dev/ttyUSB0
     restart: always

--- a/infinitude
+++ b/infinitude
@@ -17,7 +17,6 @@ use Time::HiRes qw/time/;
 use Try::Tiny;
 use XML::Simple::Minded;
 
-
 my $store = CHI->new(
     driver         => 'File',
     root_dir       => 'state',
@@ -453,14 +452,13 @@ websocket '/serial' => sub {
 			my $fstruc = $frame->frame_hash;
 			$fstruc->{timestamp} = time;
 
-            if ($fstruc->{Function} eq 'reply') {
-                my $payf = $fstruc->{payload};
-                if ($payf) {
+            if ($fstruc->{Function} eq 'reply' and $fstruc->{type}) {
+                if (my $payf = $fstruc->{payload}) {
                     if ($payf->{rows} and $ENV{SCAN_THERMOSTAT}) {
                         $scanrow = $payf->{rows}+1;
                         warn sprintf(">>>>>>>>>>> table %02x has %d rows <<<<<<<<<<<<<<<<<<<", $scantab, $payf->{rows});
                     }
-                    $fstruc->{field} = $payf;
+                    $fstruc->{field} = { $fstruc->{type}=>$fstruc->{payload} };
                 }
             }
 

--- a/infinitude
+++ b/infinitude
@@ -68,6 +68,7 @@ sub serial_init {
         require IO::Termios;
         warn "Using $config->{serial_tty} serial interface\n";
         $handle ||= IO::Termios->open($config->{serial_tty},"38400,8,n,1");
+        $handle->blocking(0);
     } else {
         warn "Can't find serial device: $config->{serial_tty}. Serial monitoring disabled.\n" if $config->{serial_tty};
         delete $config->{serial_tty};
@@ -79,8 +80,9 @@ sub serial_init {
         $port //= 'telnet';
         warn "Using $host port $port for serial interface\n";
         $handle ||= IO::Socket::IP->new( PeerHost=>$host, PeerPort=>$port);
+        $handle->blocking(0);
     }
-    $carbus = CarBus->new(async=>1, fh=>$handle) if $handle;
+    $carbus = CarBus->new(fh=>$handle) if $handle;
 }
 serial_init();
 
@@ -450,9 +452,9 @@ websocket '/serial' => sub {
 		if (my $frame = shift @inbox) {
 			my $fstruc = $frame->frame_hash;
 			$fstruc->{timestamp} = time;
-            my $reg = sprintf("%02x%02x",$frame->frame_hash->{table}, $frame->frame_hash->{row});
-            if ($fstruc->{Function} eq 'reply' and my $regparse = $frame->reg_parser($reg)) {
-                my $payf = try { $regparse->parse($frame->frame_hash->{data}); };
+
+            if ($fstruc->{Function} eq 'reply') {
+                my $payf = $fstruc->{payload};
                 if ($payf) {
                     if ($payf->{rows} and $ENV{SCAN_THERMOSTAT}) {
                         $scanrow = $payf->{rows}+1;

--- a/lib/CarBus.pm
+++ b/lib/CarBus.pm
@@ -3,12 +3,8 @@ use Moo;
 use CarBus::Frame;
 
 has async => (is=>'ro', default=>sub{0});
-has fh => (is=>'rw');
+has fh => (is=>'ro');
 has buffer => (is=>'rw', default=>'');
-has fill_buffer => (is=>'ro', default=>sub{ 
-		my $self = shift; 
-		$self->fh ? $self->fh_fill : sub{};
-	});
 
 use constant MAX_BUFFER => 1024;
 
@@ -40,17 +36,18 @@ sub get_frame {
 		} else {
 			$self->shift_stream(1);
 		}
-		$self->fill_buffer();
+		$self->fh_fill();
 	}
 	return { error=>'timed out or EOF' };
 }
 
 sub fh_fill {
-	my $self = shift;
-	my $buf = '';
-	my $len = $self->fh->sysread($buf, 1024);
-	$self->push_stream($buf);
-	return $len;
+    my $self = shift;
+    return unless $self->fh;
+    my $buf = '';
+    my $len = $self->fh->sysread($buf, 1024);
+    $self->push_stream($buf);
+    return $len;
 }
 
 sub buflen {


### PR DESCRIPTION
simplifies serial buffer fills/sync
forces non-blocking mode on net and serial ports
always parses frame payloads when possible
returns payload parser name in serial stream structure
