### PR TITLE
Fix Status page gauges: zone gauges never render, all gauges reset after updating

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -476,18 +476,18 @@
             <template x-for="(zone, zi) in status.zones[0].zone" :key="zi">
               <div x-show="zone.enabled[0] === 'on'" @click="selectZone(zone.id - 1)">
                 <h4 x-text="zone.name[0]"></h4>
-                <div class="row align-items-end text-center" x-effect="renderZoneGauges(zi)">
+                <div class="row align-items-end text-center">
                   <div class="col-6 col-sm-4 col-md-2">
-                    <div :x-ref="'gaugeZoneInside_' + zi" class="dg-linear"></div>
+                    <div class="dg-linear" x-effect="renderGauge($el, Number(zone.rt[0]), 'temperature', { title:'Inside' })"></div>
                   </div>
                   <div class="col-6 col-sm-4 col-md-2">
-                    <div :x-ref="'gaugeZoneHeat_' + zi" class="dg-linear"></div>
+                    <div class="dg-linear" x-effect="renderGauge($el, Number(zone.htsp[0]), 'temperature', { title:'Heat Setpoint' })"></div>
                   </div>
                   <div class="col-6 col-sm-4 col-md-2">
-                    <div :x-ref="'gaugeZoneCool_' + zi" class="dg-linear"></div>
+                    <div class="dg-linear" x-effect="renderGauge($el, Number(zone.clsp[0]), 'temperature', { title:'Cool Setpoint' })"></div>
                   </div>
                   <div class="col-6 col-sm-4 col-md-2" x-show="systems && systems.config[0].cfgzoning[0] === 'on'">
-                    <div :x-ref="'gaugeZoneDamper_' + zi"></div>
+                    <div x-effect="zone.damperposition && renderGauge($el, zone.damperposition[0], 'damper', { title:'Dmpr. Pos.' })"></div>
                   </div>
                 </div>
               </div>

--- a/public/scripts/app.js
+++ b/public/scripts/app.js
@@ -368,6 +368,7 @@
           if (!el) return;
           var preset = this.gaugeType(typeName);
           var opts = Object.assign({}, preset, overrides || {}, this.gaugeTheme());
+          var val = Number(value) || 0;
           if (!el._gauge) {
             var canvas = document.createElement('canvas');
             el.appendChild(canvas);
@@ -383,13 +384,17 @@
               valueDec: 0,
               animateOnInit: true,
               animationDuration: 500,
-              animationRule: 'linear'
+              animationRule: 'linear',
+              value: val
             }, opts)).draw();
           } else {
-            Object.assign(el._gauge.options, opts);
-            el._gauge.update();
+            // Pass value together with the other options in one update() call —
+            // a bare update() with no value resets the gauge to its default,
+            // and a separate el._gauge.value assignment afterward doesn't
+            // reliably repaint on an already-drawn gauge.
+            Object.assign(el._gauge.options, opts, { value: val });
+            el._gauge.update({ value: val });
           }
-          el._gauge.value = Number(value) || 0;
         },
 
         rebuildGauges: function() {
@@ -428,17 +433,6 @@
             this.renderGauge(this.$refs.gaugeFilter, s.filtrlvl[0], 'percentage', { title:'Fltr. Usage' });
           if (this.systems && this.systems.config[0].cfgvent[0] && s.ventlvl)
             this.renderGauge(this.$refs.gaugeVent, s.ventlvl[0], 'percentage', { title:'Vent. Usage' });
-        },
-
-        renderZoneGauges: function(zi) {
-          if (!this.status || !this.status.zones) return;
-          var zone = this.status.zones[0].zone[zi];
-          if (!zone || zone.enabled[0] !== 'on') return;
-          this.renderGauge(this.$refs['gaugeZoneInside_' + zi], Number(zone.rt[0]), 'temperature', { title:'Inside' });
-          this.renderGauge(this.$refs['gaugeZoneHeat_' + zi], Number(zone.htsp[0]), 'temperature', { title:'Heat Setpoint' });
-          this.renderGauge(this.$refs['gaugeZoneCool_' + zi], Number(zone.clsp[0]), 'temperature', { title:'Cool Setpoint' });
-          if (this.systems && this.systems.config[0].cfgzoning[0] === 'on' && zone.damperposition)
-            this.renderGauge(this.$refs['gaugeZoneDamper_' + zi], zone.damperposition[0], 'damper', { title:'Dmpr. Pos.' });
         },
 
         // --- Serial / WebSocket ---


### PR DESCRIPTION
Two related bugs in the Status page's gauge rendering:

1. The per-zone gauges (Inside/Heat/Cool/Damper Position) never rendered on anyone's install. They used `:x-ref="'gaugeZoneInside_' + zi"` to build a dynamic ref name per zone, but Alpine.js does not support dynamically bound `x-ref` — only a static `x-ref="name"` works. This meant `this.$refs['gaugeZoneInside_' + zi]` was always `undefined`, so `renderGauge` silently no-op'd for every per-zone gauge. Fixed by calling `renderGauge($el, ...)` directly from each gauge div via `x-effect`, using Alpine's `$el` instead of `$refs`. This also makes the `renderZoneGauges()` wrapper unnecessary, so it's removed.

2. Separately, every gauge on the Status page (including the system-wide ones, not just zone gauges) would flash to the correct reading and then reset to its minimum value shortly after. `renderGauge`'s update path called the gauge library's `update()` with no value, which resets the gauge to its default, then set `.value` separately afterward — which doesn't reliably repaint on an already-drawn gauge. Fixed by passing `value` together with the other options in a single `update()` call.

Both confirmed against a live Carrier Infinity system.

## Test plan
- [x] Verified zone gauges (Inside/Heat/Cool/Damper Position) render on the Status page and show live values
- [x] Verified system-wide gauges (Humidity, Outside, Filter, Vent, Airflow, Blower) update correctly without resetting to minimum
- [x] Confirmed against a real running Infinitude instance connected to a Carrier Infinity system
